### PR TITLE
pos fix - block 730000

### DIFF
--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -474,9 +474,7 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex)
     result.push_back(Pair("time", (boost::int64_t)block.GetBlockTime()));
     result.push_back(Pair("nonce", (boost::uint64_t)block.nNonce));
     result.push_back(Pair("bits", HexBits(block.nBits)));
-    result.push_back(Pair("PoW difficulty", GetDifficulty(blockindex)));
-    result.push_back(Pair("PoS difficulty", GetDifficulty(GetLastBlockIndex(pindexBest, true))));
-
+    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
     if (blockindex->pnext)
@@ -647,8 +645,7 @@ Value getmininginfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("currentblocksize",(uint64_t)nLastBlockSize));
     obj.push_back(Pair("currentblocktx",(uint64_t)nLastBlockTx));
-    obj.push_back(Pair("pow difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("pos difficulty", GetDifficulty(GetLastBlockIndex(pindexBest, true))));
+    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     obj.push_back(Pair("generate",      GetBoolArg("-gen")));
     obj.push_back(Pair("genproclimit",  (int)GetArg("-genproclimit", -1)));
@@ -1144,8 +1141,7 @@ Value getinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("blocks",        (int)nBestHeight));
     obj.push_back(Pair("connections",   (int)vNodes.size()));
     obj.push_back(Pair("proxy",         (addrProxy.IsValid() ? addrProxy.ToStringIPPort() : string())));
-    obj.push_back(Pair("pow difficulty",    (double)GetDifficulty()));
-    obj.push_back(Pair("pos difficulty", GetDifficulty(GetLastBlockIndex(pindexBest, true))));
+    obj.push_back(Pair("difficulty",    (double)GetDifficulty()));
     obj.push_back(Pair("testnet",       fTestNet));
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   pwalletMain->GetKeyPoolSize()));

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -8,8 +8,8 @@
 
 // These need to be macros, as version.cpp's and bitcoin-qt.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR       2
-#define CLIENT_VERSION_MINOR       0
-#define CLIENT_VERSION_REVISION    1
+#define CLIENT_VERSION_MINOR       1
+#define CLIENT_VERSION_REVISION    0
 #define CLIENT_VERSION_BUILD       0
 
 //#define CLIENT_VERSION_MAJOR       DISPLAY_VERSION_MAJOR

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1181,7 +1181,7 @@ unsigned int static DarkGravityWave3(const CBlockIndex* pindexLast, bool fProofO
 }
 
 // for pos
-unsigned int GetNextTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake)
+unsigned int GetNextPosTargetRequired(const CBlockIndex* pindexLast, bool fProofOfStake)
 {
   CBigNum bnTargetLimit = bnProofOfStakeLimit;
 
@@ -4164,7 +4164,7 @@ CBlock* CreateNewBlock(CWallet* pwallet, bool fProofOfStake)
 
     if (fProofOfStake)  // attempt to find a coinstake
     {
-        pblock->nBits = GetNextTargetRequired(pindexPrev, true);
+        pblock->nBits = GetNextPosTargetRequired(pindexPrev, true);
         CTransaction txCoinStake;
         int64 nSearchTime = txCoinStake.nTime; // search to current time
         if (nSearchTime > nLastCoinStakeSearchTime)

--- a/src/main.h
+++ b/src/main.h
@@ -51,8 +51,8 @@ extern int nCoinbaseMaturity;
 
 static const int64 MAX_MINT_PROOF_OF_STAKE = 0.15 * COIN;	// 15% annual interest
 
-//static const int POS_START_BLOCK = 640000;
-static const int POS_START_BLOCK = 100;
+static const int POS_START_BLOCK = 640000;
+static const int POS_FIX_BLOCK=730000;
 
 static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours
 
@@ -467,7 +467,6 @@ public:
         READWRITE(nLockTime);
 
         if(nVersion > 2) 
-//        if((nVersion > POW_VERSION) &&(nBestHeight > 370000))
           READWRITE(nTime);
     )
 
@@ -856,7 +855,7 @@ class CBlock
 {
 public:
     // header
-    static const int CURRENT_VERSION=2;
+    static const int CURRENT_VERSION=3;
     int nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/main.h
+++ b/src/main.h
@@ -51,7 +51,7 @@ extern int nCoinbaseMaturity;
 
 static const int64 MAX_MINT_PROOF_OF_STAKE = 0.15 * COIN;	// 15% annual interest
 
-static const int POS_START_BLOCK = 640000;
+//static const int POS_START_BLOCK = 640000;
 static const int POS_START_BLOCK = 100;
 
 static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours

--- a/src/main.h
+++ b/src/main.h
@@ -50,7 +50,10 @@ static const int COINBASE_MATURITY = 100;
 extern int nCoinbaseMaturity;
 
 static const int64 MAX_MINT_PROOF_OF_STAKE = 0.15 * COIN;	// 15% annual interest
+
 static const int POS_START_BLOCK = 640000;
+static const int POS_START_BLOCK = 100;
+
 static const int64 nMaxClockDrift = 2 * 60 * 60;        // two hours
 
 // time to switch to KimotoGravityWell


### PR DESCRIPTION
edits to pow difficulty adjustments - old code looked at the last block for difficulty - which might be a pos block, dropping pow diff to what pos diff is - no it only looks at previous pow blocks.
upped version to 2.1.0.0
blocked older clients from connecting after pos_fix_block
also removed separate listing of pos/pow difficulty in getinfo and getminingifo - it messes up the block explorer and some pools.